### PR TITLE
CDPS-2016: Provide telemetry client interface + remove appinsights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 Please use this to capture reasoning behind changes:
 
+## 4.0.0
+
+`applicationinsights` has been removed as a dependency.
+
+Previously, `PermissionsService.create()` accepted a `TelemetryClient` imported from `applicationinsights`.
+It now accepts anything satisfying a simple `TelemetryClient` interface which this library exports.
+
+### Upgrading
+
+The `TelemetryClient` interface has this signature:
+
+```typescript
+trackEvent(name: string, attributes?: Record<string, string | number | boolean>): void
+```
+
+It's recommended to use `@ministryofjustice/hmpps-azure-telemetry` because the telemetry client it provides matches the interface directly:
+
+```typescript
+import { telemetry } from '@ministryofjustice/hmpps-azure-telemetry'
+
+const prisonPermissionsService = PermissionsService.create({
+  ...
+  telemetryClient: telemetry,
+})
+```
+
+If using the `applicationinsights` package, please note:
+The `applicationinsights` `TelemetryClient` uses a very similar yet slightly different `trackEvent` signature, so you will need to wrap it.
+
+If you are not passing a telemetry client (not recommended), no changes are needed.
+
 ## 3.0.1
 
 Updated dependencies

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ The permissions service should be created just like any other of your services. 
   in order to make authorized client credentials calls to Prisoner Search.
 * `logger`: Bunyan logger for logging permissions events. Defaults to using `console`.
 * `telemetryClient`: Optional but recommended. Instead of just logging permissions events, this provides richer metadata
-  to Application Insights.
+  to a telemetry provider. Provide a client satisfying the `TelemetryClient` interface that this library exports (requires only a `trackEvent` method). 
+  Compatible with `@ministryofjustice/hmpps-azure-telemetry` as-is. Compatible with `applicationinsights` if a wrapper is made to match the interface.
 * `readOnly`: Optional boolean (defaults to false) which, if set to true, will only grant read permissions.
 
 e.g.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "rollup": "4.62.2",
         "rollup-plugin-dts": "6.4.1",
         "ts-jest": "29.4.11",
+        "tslib": "2.8.1",
         "typescript": "6.0.3"
       },
       "engines": {
@@ -9861,8 +9862,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "lint-staged": "17.0.8",
     "rollup": "4.62.2",
     "rollup-plugin-dts": "6.4.1",
+    "tslib": "2.8.1",
     "ts-jest": "29.4.11",
     "typescript": "6.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-prison-permissions-lib",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "A library to centralise the process of determining whether a user should have access to create/read/update/delete a prison resource, for example, accessing a prisoner's Prisoner Profile.",
   "keywords": [
     "hmpps",
@@ -70,7 +70,6 @@
     "typescript": "6.0.3"
   },
   "dependencies": {
-    "@ministryofjustice/hmpps-rest-client": "2.1.0",
-    "applicationinsights": "^2.9.8"
+    "@ministryofjustice/hmpps-rest-client": "2.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,6 @@ export { default as prisonerPermissionsGuard } from './middleware/PrisonerPermis
 
 // View:
 export { default as setupNunjucksPermissions } from './view/SetupNunjucksPermissions'
+
+// Telemetry:
+export type { TelemetryClient } from './types/public/telemetry/TelemetryClient'

--- a/src/services/permissions/PermissionsLogger.test.ts
+++ b/src/services/permissions/PermissionsLogger.test.ts
@@ -1,5 +1,5 @@
 import Logger from 'bunyan'
-import { TelemetryClient } from 'applicationinsights'
+import { TelemetryClient } from '../../types/public/telemetry/TelemetryClient'
 import PermissionsLogger from './PermissionsLogger'
 import { PrisonUser } from '../../types/internal/user/HmppsUser'
 import Prisoner from '../../data/hmppsPrisonerSearch/interfaces/Prisoner'
@@ -40,15 +40,12 @@ describe('PermissionsLogger', () => {
 
       permissionsLogger.logPermissionCheckStatus(user, prisoner, permission, permissionCheckStatus)
 
-      expect(telemetryClient.trackEvent).toHaveBeenCalledWith({
-        name: 'prisoner-permission-denied',
-        properties: {
-          username: user.username,
-          prisonerNumber: prisoner.prisonerNumber,
-          activeCaseLoad: user.activeCaseLoadId,
-          permissionChecked: permission,
-          status: permissionCheckStatus,
-        },
+      expect(telemetryClient.trackEvent).toHaveBeenCalledWith('prisoner-permission-denied', {
+        username: user.username,
+        prisonerNumber: prisoner.prisonerNumber,
+        activeCaseLoad: user.activeCaseLoadId,
+        permissionChecked: permission,
+        status: permissionCheckStatus,
       })
 
       expect(logger.info).not.toHaveBeenCalled()

--- a/src/services/permissions/PermissionsLogger.ts
+++ b/src/services/permissions/PermissionsLogger.ts
@@ -1,5 +1,5 @@
-import { TelemetryClient } from 'applicationinsights'
 import type Logger from 'bunyan'
+import { TelemetryClient } from '../../types/public/telemetry/TelemetryClient'
 import { PermissionCheckStatus } from '../../types/internal/permissions/PermissionCheckStatus'
 import { HmppsUser } from '../../types/internal/user/HmppsUser'
 import Prisoner from '../../data/hmppsPrisonerSearch/interfaces/Prisoner'
@@ -20,15 +20,12 @@ export default class PermissionsLogger {
     if (permissionCheckStatus === PermissionCheckStatus.OK) return
 
     if (this.telemetryClient) {
-      this.telemetryClient.trackEvent({
-        name: 'prisoner-permission-denied',
-        properties: {
-          username: user.username,
-          prisonerNumber: prisoner.prisonerNumber,
-          activeCaseLoad: user.authSource === 'nomis' && user.activeCaseLoadId,
-          permissionChecked: permission,
-          status: permissionCheckStatus,
-        },
+      this.telemetryClient.trackEvent('prisoner-permission-denied', {
+        username: user.username,
+        prisonerNumber: prisoner.prisonerNumber,
+        activeCaseLoad: user.authSource === 'nomis' ? user.activeCaseLoadId : 'false',
+        permissionChecked: permission,
+        status: permissionCheckStatus,
       })
     } else {
       this.logger.info(`Prisoner permission denied: ${permission} (${permissionCheckStatus}) for user ${user.username}`)
@@ -42,15 +39,12 @@ export default class PermissionsLogger {
     permission: PrisonerPermission,
   ) {
     if (this.telemetryClient) {
-      this.telemetryClient.trackEvent({
-        name: 'prisoner-permission-requirement-upgraded-by-duplicate',
-        properties: {
-          username: user.username,
-          prisonerNumber: prisoner.prisonerNumber,
-          duplicatePrisonerNumbers: duplicateRecords.map(record => record.prisonerNumber).join(','),
-          activeCaseLoad: user.authSource === 'nomis' && user.activeCaseLoadId,
-          permissionChecked: permission,
-        },
+      this.telemetryClient.trackEvent('prisoner-permission-requirement-upgraded-by-duplicate', {
+        username: user.username,
+        prisonerNumber: prisoner.prisonerNumber,
+        duplicatePrisonerNumbers: duplicateRecords.map(record => record.prisonerNumber).join(','),
+        activeCaseLoad: user.authSource === 'nomis' ? user.activeCaseLoadId : 'false',
+        permissionChecked: permission,
       })
     } else {
       this.logger.info(`Required prisoner permission upgraded by duplicate: ${permission} for user ${user.username}`)

--- a/src/services/permissions/PermissionsLogger.ts
+++ b/src/services/permissions/PermissionsLogger.ts
@@ -23,7 +23,7 @@ export default class PermissionsLogger {
       this.telemetryClient.trackEvent('prisoner-permission-denied', {
         username: user.username,
         prisonerNumber: prisoner.prisonerNumber,
-        activeCaseLoad: user.authSource === 'nomis' ? user.activeCaseLoadId : 'false',
+        activeCaseLoad: user.authSource === 'nomis' ? user.activeCaseLoadId : '',
         permissionChecked: permission,
         status: permissionCheckStatus,
       })
@@ -43,7 +43,7 @@ export default class PermissionsLogger {
         username: user.username,
         prisonerNumber: prisoner.prisonerNumber,
         duplicatePrisonerNumbers: duplicateRecords.map(record => record.prisonerNumber).join(','),
-        activeCaseLoad: user.authSource === 'nomis' ? user.activeCaseLoadId : 'false',
+        activeCaseLoad: user.authSource === 'nomis' ? user.activeCaseLoadId : '',
         permissionChecked: permission,
       })
     } else {

--- a/src/services/permissions/PermissionsService.ts
+++ b/src/services/permissions/PermissionsService.ts
@@ -1,6 +1,6 @@
 import type bunyan from 'bunyan'
 import { ApiConfig, AuthenticationClient } from '@ministryofjustice/hmpps-rest-client'
-import { TelemetryClient } from 'applicationinsights'
+import { TelemetryClient } from '../../types/public/telemetry/TelemetryClient'
 import Prisoner from '../../data/hmppsPrisonerSearch/interfaces/Prisoner'
 import { HmppsUser } from '../../types/internal/user/HmppsUser'
 import PermissionsLogger from './PermissionsLogger'

--- a/src/types/public/telemetry/TelemetryClient.ts
+++ b/src/types/public/telemetry/TelemetryClient.ts
@@ -1,0 +1,3 @@
+export interface TelemetryClient {
+  trackEvent(name: string, attributes?: Record<string, string | number | boolean>): void
+}


### PR DESCRIPTION
+ TelemetryClient interface based on hmpps azure telemetry
+ removed appinsights dependency
+ Edited usage to fit interface.
+ Added tslib explicity as a devdep because ci tests were failing, it was transitive before.