### PR TITLE
Enhance prisonerPermissionsGuard to support both AND as well as OR roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-prison-permissions-lib",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "A library to centralise the process of determining whether a user should have access to create/read/update/delete a prison resource, for example, accessing a prisoner's Prisoner Profile.",
   "keywords": [
     "hmpps",

--- a/src/middleware/PrisonerPermissionsGuard.test.ts
+++ b/src/middleware/PrisonerPermissionsGuard.test.ts
@@ -13,6 +13,7 @@ import PermissionsService from '../services/permissions/PermissionsService'
 import { prisonerPermissionPaths } from '../types/public/permissions/prisoner/PrisonerPermissionPaths'
 import { setPrisonerPermission } from '../services/permissions/utils/PermissionUtils'
 import { prisonerPermissionsMock } from '../testUtils/PrisonerPermissionsMock'
+import { PrisonerMovesPermission } from '../types/public/permissions/domains/runningAPrison/prisonerMoves/PrisonerMovesPermissions'
 
 const examplePermissions = {
   [PrisonerBasePermission.read]: true,
@@ -97,6 +98,42 @@ describe('PrisonerPermissionsGuard', () => {
       await permissionsGuard(req, res, next)
 
       expectRequestDenied([PersonSentenceCalculationPermission.read])
+    })
+
+    it('request succeeds with matchAll false when one permission check passes', async () => {
+      const permissions = {
+        ...setPrisonerPermission(PersonSentenceCalculationPermission.read, false, prisonerPermissionsMock),
+        [PrisonerBasePermission.read]: true,
+      } as unknown as PrisonerPermissions
+
+      permissionsService.getPrisonerPermissions = jest.fn(() => permissions)
+
+      permissionsGuard = prisonerPermissionsGuard(permissionsService, {
+        requestDependentOn: [PrisonerBasePermission.read, PersonSentenceCalculationPermission.read],
+        matchAll: false,
+      })
+
+      await permissionsGuard(req, res, next)
+
+      expectRequestAllowed(permissions)
+    })
+
+    it('request fails with matchAll false when all permission checks fail', async () => {
+      const permissions = {
+        ...setPrisonerPermission(PersonSentenceCalculationPermission.read, false, prisonerPermissionsMock),
+        [PrisonerBasePermission.read]: true,
+      } as unknown as PrisonerPermissions
+
+      permissionsService.getPrisonerPermissions = jest.fn(() => permissions)
+
+      permissionsGuard = prisonerPermissionsGuard(permissionsService, {
+        requestDependentOn: [PrisonerMovesPermission.read_temporary_absence, PersonSentenceCalculationPermission.read],
+        matchAll: false,
+      })
+
+      await permissionsGuard(req, res, next)
+
+      expectRequestDenied([PrisonerBasePermission.read, PersonSentenceCalculationPermission.read])
     })
 
     it('request fails when multiple permission checks fail', async () => {

--- a/src/middleware/PrisonerPermissionsGuard.ts
+++ b/src/middleware/PrisonerPermissionsGuard.ts
@@ -10,9 +10,10 @@ export default function prisonerPermissionsGuard(
   options: {
     requestDependentOn: PrisonerPermission[]
     getPrisonerNumberFunction?: (req: Request) => string | undefined
+    matchAll?: boolean
   },
 ) {
-  const { requestDependentOn, getPrisonerNumberFunction = getPrisonerNumberFrom } = options
+  const { requestDependentOn, getPrisonerNumberFunction = getPrisonerNumberFrom, matchAll = true } = options
 
   if (!requestDependentOn?.length) throw Error('Unprotected route, must provide at least one dependent permission')
 
@@ -35,8 +36,11 @@ export default function prisonerPermissionsGuard(
     })
 
     const deniedPermissions = requestDependentOn.filter(permission => !isGranted(permission, prisonerPermissions))
+    const isAccessDenied = matchAll
+      ? deniedPermissions.length > 0
+      : deniedPermissions.length === requestDependentOn.length
 
-    if (deniedPermissions.length) return next(new PrisonerPermissionError('Denied permissions', deniedPermissions))
+    if (isAccessDenied) return next(new PrisonerPermissionError('Denied permissions', deniedPermissions))
 
     req.middleware = { ...req.middleware, prisonerData }
     res.locals.prisonerPermissions = prisonerPermissions


### PR DESCRIPTION
Default Usage: prisoner with only PrisonerMovesPermission.read_temporary_absence is denied

```
permissionsGuard = prisonerPermissionsGuard(permissionsService, {
        requestDependentOn: [PrisonerMovesPermission.read_temporary_absence, PersonSentenceCalculationPermission.read],
      })
```

MatchAll false: prisoner with only PrisonerMovesPermission.read_temporary_absence is allowed

```
permissionsGuard = prisonerPermissionsGuard(permissionsService, {
        requestDependentOn: [PrisonerMovesPermission.read_temporary_absence, PersonSentenceCalculationPermission.read],
        matchAll: false,
      })
```